### PR TITLE
Fix inter-document linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+## 0.1.1
+
+### Fixed
+
+* Links to Markdown resources are now URI-ified:
+  * `[](location.md)` → `{"id": "location"}`
+  * `[](location.md#section)` → `{"id": "location#section"}`

--- a/articular/templates/html_to_xml.xsl
+++ b/articular/templates/html_to_xml.xsl
@@ -290,7 +290,8 @@
     <!-- Location. -->
     <xsl:if test="@href != ''">
         <id>
-            <xsl:value-of select="@href"/>
+            <!-- Patch out .md suffix. -->
+            <xsl:value-of select="re:replace(@href, '(\.md)(?=#[\w-]+){0,}', 'g', '')"/>
         </id>
     </xsl:if>
     <!-- Type. -->

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='articular',
-    version='0.1.0',
+    version='0.1.1',
     description='Create knowledge graphs from Markdown documents.',
     url='https://github.com/edwardanderson/articular',
     author='Edward Anderson',


### PR DESCRIPTION
Allow users to reference Markdown resources in documents (so that local navigation is supported) but patch our the `.md` extensions in the `id` links when creating data.

Bump version.

Fixes #18.