### PR TITLE
autodetect xsd: type for dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 2.3.0
+
+* Support for typographic conventions like (c)
+* Granular detection of `xsd` type when user specifies `date`
+
 # 2.2.1
 
 * Fix failure to map 'a' to `rdf:type` caused by unexpected newline

--- a/articular/xsl/p.xsl
+++ b/articular/xsl/p.xsl
@@ -58,21 +58,55 @@
     <xsl:template match="p[not(strong|em|del)][code]">
         <xsl:choose>
             <!-- Datatype -->
-            <xsl:when test="code=('date', 'integer', 'boolean')">
+            <xsl:when test="code=('integer', 'boolean')">
                 <string key="@type">
                     <xsl:value-of select="concat('xsd:', code)"/>
                 </string>
+                <string key="@value">
+                    <xsl:apply-templates select="text()"/>
+                </string>
             </xsl:when>
-            <!-- BCp 47 language -->
+            <xsl:when test="code = 'date'">
+                <xsl:choose>
+                    <!-- gYear -->
+                    <xsl:when test="matches(text(), '^-?\d+\s*$')">
+                        <string key="@type">
+                            <xsl:value-of select="'xsd:gYear'"/>
+                        </string>
+                        <string key="@value">
+                            <xsl:apply-templates select="text()"/>
+                        </string>
+                    </xsl:when>
+                    <!-- gMonth -->
+                    <xsl:when test="matches(text(), '^-?\d+-[01][0-9]{1}\s*$')">
+                        <string key="@type">
+                            <xsl:value-of select="'xsd:gMonth'"/>
+                        </string>
+                        <string key="@value">
+                            <xsl:apply-templates select="text()"/>
+                        </string>
+                    </xsl:when>
+                    <!-- Date -->
+                    <xsl:when test="matches(text(), '^-?\d+-[01]{1}[0-9]{1}-[0123]{1}[0-9]{1}\s*$')">
+                        <string key="@type">
+                            <xsl:value-of select="'xsd:date'"/>
+                        </string>
+                        <string key="@value">
+                            <xsl:apply-templates select="text()"/>
+                        </string>
+                    </xsl:when>
+                </xsl:choose>
+            </xsl:when>
+            <!-- BCP 47 language -->
             <xsl:when test="matches(code, '^[a-z]{2}(-[A-Z]{2})?$')">
                 <string key="@language">
                     <xsl:value-of select="code"/>
                 </string>
+                <string key="@value">
+                    <xsl:apply-templates select="text()"/>
+                </string>
             </xsl:when>
         </xsl:choose>
-        <string key="@value">
-            <xsl:apply-templates select="text()"/>
-        </string>
     </xsl:template>
 
     <!-- HTML (without language or datatype) -->

--- a/examples/adventures_of_huckleberry_finn.json
+++ b/examples/adventures_of_huckleberry_finn.json
@@ -49,7 +49,7 @@
           "source": [
             {
               "@id": "https://en.wikipedia.org/wiki/Adventures_of_Huckleberry_Finn",
-              "_label": "\"Adventures of Huckleberry Finn\", Wikipedia"
+              "_label": "“Adventures of Huckleberry Finn”, Wikipedia"
             }
           ]
         }

--- a/examples/adventures_of_huckleberry_finn.trig
+++ b/examples/adventures_of_huckleberry_finn.trig
@@ -9,7 +9,7 @@
     <http://example.org/1> a :Book ;
         rdfs:label "Adventures of Huckleberry Finn"@en ;
         :author <http://www.wikidata.org/entity/Q7245> ;
-        :description _:N0ff569a9573240ee97918dbce6c85c22 .
+        :description _:N68ad2aab4b444018820d28584bd08c4f .
 
     <http://www.wikidata.org/entity/Q7245> rdfs:label "Mark Twain"@en ;
         :date_of_birth "1835-11-30"^^xsd:date ;
@@ -17,11 +17,11 @@
             "صمويل لانغهورن كليمنس"@ar,
             "塞姆·朗赫恩·克莱門斯"@zh .
 
-    <https://en.wikipedia.org/wiki/Adventures_of_Huckleberry_Finn> rdfs:label "\"Adventures of Huckleberry Finn\", Wikipedia"@en .
+    <https://en.wikipedia.org/wiki/Adventures_of_Huckleberry_Finn> rdfs:label "“Adventures of Huckleberry Finn”, Wikipedia"@en .
 
     <https://en.wikipedia.org/wiki/Mark_Twain> rdfs:label "Mark Twain"@en .
 
-    _:N0ff569a9573240ee97918dbce6c85c22 a html:blockquote ;
+    _:N68ad2aab4b444018820d28584bd08c4f a html:blockquote ;
         rdf:value "<p lang=\"en\"><strong>Adventures of Huckleberry Finn</strong> is a novel by American author <a href=\"https://en.wikipedia.org/wiki/Mark_Twain\">Mark Twain</a>.</p>"^^rdf:HTML ;
         rdfs:seeAlso <https://en.wikipedia.org/wiki/Mark_Twain> ;
         schema:isBasedOn <https://en.wikipedia.org/wiki/Adventures_of_Huckleberry_Finn> .

--- a/examples/adventures_of_huckleberry_finn.ttl
+++ b/examples/adventures_of_huckleberry_finn.ttl
@@ -19,7 +19,7 @@
         "صمويل لانغهورن كليمنس"@ar,
         "塞姆·朗赫恩·克莱門斯"@zh .
 
-<https://en.wikipedia.org/wiki/Adventures_of_Huckleberry_Finn> rdfs:label "\"Adventures of Huckleberry Finn\", Wikipedia"@en .
+<https://en.wikipedia.org/wiki/Adventures_of_Huckleberry_Finn> rdfs:label "“Adventures of Huckleberry Finn”, Wikipedia"@en .
 
 <https://en.wikipedia.org/wiki/Mark_Twain> rdfs:label "Mark Twain"@en .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 66.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "2.2.1"
+version = "2.3.0"
 name = "Articular"
 description = "Create RDF knowledge graphs with Markdown."
 keywords = [


### PR DESCRIPTION
Improves detection of specific `xsd` type when user specifies `date`. Regex still fairly naïve.