### PR TITLE
feature/definition-lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 2.4.0
+
+* Support definition lists for subjects and objects
+
 # 2.3.0
 
 * Support for typographic conventions like (c)

--- a/articular/xsl/document.xsl
+++ b/articular/xsl/document.xsl
@@ -39,7 +39,7 @@
     <xsl:import href="ul.xsl"/>
 
     <!-- Document -->
-    <xsl:template match="/">
+    <xsl:template match="/document">
         <xsl:variable name="xml">
             <map>
                 <!-- @context -->

--- a/articular/xsl/identifier.xsl
+++ b/articular/xsl/identifier.xsl
@@ -5,11 +5,17 @@
     xmlns="http://www.w3.org/2005/xpath-functions">
 
     <!-- Blank -->
-    <xsl:template match="li[not(a|img|blockquote)]" mode="identifier">
+    <xsl:template match="li[not(a|img|blockquote)][not(node() = /document/dl/dt)]" mode="identifier">
         <string key="@id">
             <xsl:text>_:</xsl:text>
             <xsl:apply-templates select="node()[not(self::code)]" mode="plain-text"/>
         </string>
+    </xsl:template>
+
+    <!-- Defined -->
+    <xsl:template match="li[not(a|img|blockquote)][node() = /document/dl/dt]" mode="identifier">
+        <xsl:variable name="value" select="text()"/>
+        <xsl:apply-templates select="/document/dl/dt[node() = $value]/following-sibling::dd[1]/a/@href" mode="identifier"/>
     </xsl:template>
 
     <!-- Identified -->

--- a/articular/xsl/label.xsl
+++ b/articular/xsl/label.xsl
@@ -4,8 +4,24 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns="http://www.w3.org/2005/xpath-functions">
    
+    <!-- Label (defined) -->
+    <xsl:template match="li[not(code or (strong|em|del))][node() = /document/dl/dt]" mode="label">
+        <xsl:variable name="value" select="text()"/>
+        <string key="_label">
+            <xsl:variable name="a" select="/document/dl/dt[node() = $value]/following-sibling::dd[1]/a"/>
+            <xsl:choose>
+                <xsl:when test="$a/@href != a/text()">
+                    <xsl:apply-templates select="/document/dl/dt[node() = $value]/following-sibling::dd[1]/a/text()" mode="label"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:apply-templates select="text()" mode="label"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </string>
+    </xsl:template>
+
     <!-- Label (without language) -->
-    <xsl:template match="(li|a|img)[not(code or (strong|em|del))]" mode="label">
+    <xsl:template match="(li|a|img)[not(code or (strong|em|del))][not(node() = /document/dl/dt)]" mode="label">
         <string key="_label">
             <xsl:apply-templates select="@alt|text()"/>
         </string>

--- a/examples/features/definition_list.md
+++ b/examples/features/definition_list.md
@@ -1,0 +1,16 @@
+* The Beatles
+  * formed in
+    * Liverpool
+  * member
+    * John
+      * born in
+        * Liverpool
+    * Paul
+    * George
+    * Ringo
+
+The Beatles
+: <http://www.wikidata.org/entity/Q1299>
+
+Liverpool
+: <https://vocab.getty.edu/tgn/7010597>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 66.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "2.3.0"
+version = "2.4.0"
 name = "Articular"
 description = "Create RDF knowledge graphs with Markdown."
 keywords = [


### PR DESCRIPTION
Simple handling for definition lists to enable lazy aliasing of subject/object terms.

Closes https://github.com/edwardanderson/articular/issues/4