### PR TITLE
fix/dl-see-also

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 2.9.1
+
+- Fix bug in blockquote hyperlink label mapping to `rdfs:seeAlso`
+
 ## 2.9.0
 
-- Generate `owl:sameAs` relations for entities with two or more definition list entries.
+- Generate `owl:sameAs` relations for entities with two or more definition list entries
 
 ## 2.8.0
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ language: en
       - [source](https://schema.org/isBasedOn)
         - ["Adventures of Huckleberry Finn", Wikipedia](https://en.wikipedia.org/wiki/Adventures_of_Huckleberry_Finn)
   - author
-    - [Mark Twain](http://www.wikidata.org/entity/Q7245)
+    - Mark Twain
       - date of birth
         - > 1835-11-30 `date`
       - name
@@ -56,6 +56,11 @@ language: en
             - [Sarony](http://www.wikidata.org/entity/Q101243225)
       - description
         - ["Mark Twain", Wikipedia](https://en.wikipedia.org/wiki/Mark_Twain)
+
+Mark Twain
+: <http://www.wikidata.org/entity/Q2599>
+: <http://viaf.org/viaf/100252012>
+: <https://vocab.getty.edu/ulan/500249736>
 ```
 
 ### Output

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ language: en
         - ["Mark Twain", Wikipedia](https://en.wikipedia.org/wiki/Mark_Twain)
 
 Mark Twain
-: <http://www.wikidata.org/entity/Q2599>
-: <http://viaf.org/viaf/100252012>
-: <https://vocab.getty.edu/ulan/500249736>
+: <http://www.wikidata.org/entity/Q7245>
+: <http://viaf.org/viaf/50566653>
+: <https://vocab.getty.edu/ulan/500020427>
 ```
 
 ### Output

--- a/articular/xsl/blockquote.xsl
+++ b/articular/xsl/blockquote.xsl
@@ -36,7 +36,7 @@
     </xsl:template>
 
     <!-- See also -->
-    <xsl:template match="a|img" mode="reference">
+    <xsl:template match="p/(a|img)" mode="reference">
         <map>
             <xsl:apply-templates select="."/>
         </map>

--- a/articular/xsl/dl.xsl
+++ b/articular/xsl/dl.xsl
@@ -11,8 +11,8 @@
 
     <!-- Same as -->
     <xsl:template match="dt">
-        <xsl:variable name="term" select="generate-id(.)"/>
         <xsl:variable name="label" select="text()"/>
+        <xsl:variable name="term" select="generate-id(.)"/>
         <xsl:if test="count(following-sibling::dd[generate-id(preceding-sibling::dt[1]) = $term]) gt 1">
             <map>
                 <string key="@id">

--- a/articular/xsl/document.xsl
+++ b/articular/xsl/document.xsl
@@ -77,6 +77,7 @@
             </map>
         </xsl:variable>
         <xsl:value-of select="xml-to-json($xml)"/>
+        <!-- <xsl:value-of select="serialize($xml)"/> -->
     </xsl:template>
 
 </xsl:stylesheet>

--- a/articular/xsl/label.xsl
+++ b/articular/xsl/label.xsl
@@ -21,7 +21,7 @@
     </xsl:template>
 
     <!-- Label (without language) -->
-    <xsl:template match="(li|a|img)[not(code or (strong|em|del))]" mode="label">
+    <xsl:template match="(li[not(node() = /document/dl/dt)]|a|img)[not(code or (strong|em|del))]" mode="label">
         <xsl:choose>
             <!-- Parent paragraph language -->
             <xsl:when test="../code">

--- a/articular/xsl/label.xsl
+++ b/articular/xsl/label.xsl
@@ -21,7 +21,7 @@
     </xsl:template>
 
     <!-- Label (without language) -->
-    <xsl:template match="(li|a|img)[not(code or (strong|em|del))][not(node() = /document/dl/dt)]" mode="label">
+    <xsl:template match="(li|a|img)[not(code or (strong|em|del))]" mode="label">
         <xsl:choose>
             <!-- Parent paragraph language -->
             <xsl:when test="../code">

--- a/examples/adventures_of_huckleberry_finn.json
+++ b/examples/adventures_of_huckleberry_finn.json
@@ -8,12 +8,17 @@
       "dc": "http://purl.org/dc/elements/1.1/",
       "dcmit": "http://purl.org/dc/dcmitype/",
       "html": "http://www.w3.org/1999/xhtml/",
+      "owl": "http://www.w3.org/2002/07/owl#",
       "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
       "schema": "https://schema.org/",
       "xsd": "http://www.w3.org/2001/XMLSchema#",
       "_label": {
         "@id": "rdfs:label"
+      },
+      "_sameAs": {
+        "@id": "owl:sameAs",
+        "@container": "@set"
       },
       "_seeAlso": {
         "@id": "rdfs:seeAlso",
@@ -73,10 +78,7 @@
       "author": [
         {
           "@id": "http://www.wikidata.org/entity/Q7245",
-          "_label": {
-            "@language": "en",
-            "@value": "Mark Twain"
-          },
+          "_label": "Mark Twain",
           "date_of_birth": [
             {
               "@type": "xsd:date",
@@ -125,6 +127,20 @@
               }
             }
           ]
+        }
+      ]
+    },
+    {
+      "@id": "http://www.wikidata.org/entity/Q7245",
+      "_label": "Mark Twain",
+      "_sameAs": [
+        {
+          "@id": "http://viaf.org/viaf/50566653",
+          "_label": "Mark Twain"
+        },
+        {
+          "@id": "https://vocab.getty.edu/ulan/500020427",
+          "_label": "Mark Twain"
         }
       ]
     }

--- a/examples/adventures_of_huckleberry_finn.md
+++ b/examples/adventures_of_huckleberry_finn.md
@@ -25,6 +25,6 @@ language: en
         - ["Mark Twain", Wikipedia](https://en.wikipedia.org/wiki/Mark_Twain)
 
 Mark Twain
-: <http://www.wikidata.org/entity/Q2599>
-: <http://viaf.org/viaf/100252012>
-: <https://vocab.getty.edu/ulan/500249736>
+: <http://www.wikidata.org/entity/Q7245>
+: <http://viaf.org/viaf/50566653>
+: <https://vocab.getty.edu/ulan/500020427>

--- a/examples/adventures_of_huckleberry_finn.md
+++ b/examples/adventures_of_huckleberry_finn.md
@@ -10,7 +10,7 @@ language: en
       - [source](https://schema.org/isBasedOn)
         - ["Adventures of Huckleberry Finn", Wikipedia](https://en.wikipedia.org/wiki/Adventures_of_Huckleberry_Finn)
   - author
-    - [Mark Twain](http://www.wikidata.org/entity/Q7245)
+    - Mark Twain
       - date of birth
         - > 1835-11-30 `date`
       - name
@@ -23,3 +23,8 @@ language: en
             - [Sarony](http://www.wikidata.org/entity/Q101243225)
       - description
         - ["Mark Twain", Wikipedia](https://en.wikipedia.org/wiki/Mark_Twain)
+
+Mark Twain
+: <http://www.wikidata.org/entity/Q2599>
+: <http://viaf.org/viaf/100252012>
+: <https://vocab.getty.edu/ulan/500249736>

--- a/examples/adventures_of_huckleberry_finn.trig
+++ b/examples/adventures_of_huckleberry_finn.trig
@@ -2,16 +2,24 @@
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dcmitype: <http://purl.org/dc/dcmitype/> .
 @prefix html: <http://www.w3.org/1999/xhtml/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
+{
+    <http://example.org/adventures_of_huckleberry_finn.md> dc:format "text/markdown" ;
+        dc:type dcmitype:Dataset .
+}
+
 <http://example.org/adventures_of_huckleberry_finn.md> {
     <http://example.org/1> a :Book ;
         rdfs:label "Adventures of Huckleberry Finn"@en ;
         :author <http://www.wikidata.org/entity/Q7245> ;
-        :description _:N0cd5b0137b9d4bc9a3f3d4b5e9490718 .
+        :description _:Nf315b2294b4f40eca6ae1d311f8e114b .
+
+    <http://viaf.org/viaf/50566653> rdfs:label "Mark Twain"@en .
 
     <http://www.wikidata.org/entity/Q101243225> rdfs:label "Sarony"@en .
 
@@ -21,7 +29,9 @@
         :name "صمويل لانغهورن كليمنس"@ar,
             "Samuel Longhorn Clemens"@en,
             "塞姆·朗赫恩·克莱門斯"@zh ;
-        :portrait <https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/Mark_Twain_by_Sarony%2C_1884.JPG/155px-Mark_Twain_by_Sarony%2C_1884.JPG> .
+        :portrait <https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/Mark_Twain_by_Sarony%2C_1884.JPG/155px-Mark_Twain_by_Sarony%2C_1884.JPG> ;
+        owl:sameAs <http://viaf.org/viaf/50566653>,
+            <https://vocab.getty.edu/ulan/500020427> .
 
     <https://en.wikipedia.org/wiki/Adventures_of_Huckleberry_Finn> rdfs:label "“Adventures of Huckleberry Finn”, Wikipedia"@en .
 
@@ -29,18 +39,15 @@
         rdfs:label "Mark Twain by Sarony, 1884"@en ;
         :creator <http://www.wikidata.org/entity/Q101243225> .
 
+    <https://vocab.getty.edu/ulan/500020427> rdfs:label "Mark Twain"@en .
+
     <https://en.wikipedia.org/wiki/Mark_Twain> rdfs:label "Mark Twain"@en,
             "“Mark Twain”, Wikipedia"@en .
 
-    _:N0cd5b0137b9d4bc9a3f3d4b5e9490718 a html:blockquote ;
+    _:Nf315b2294b4f40eca6ae1d311f8e114b a html:blockquote ;
         rdf:value "<p lang=\"en\"><strong>Adventures of Huckleberry Finn</strong> is a novel by American author <a href=\"https://en.wikipedia.org/wiki/Mark_Twain\">Mark Twain</a>.</p>"^^rdf:HTML ;
         rdfs:seeAlso <https://en.wikipedia.org/wiki/Mark_Twain> ;
         schema:isBasedOn <https://en.wikipedia.org/wiki/Adventures_of_Huckleberry_Finn> .
-}
-
-{
-    <http://example.org/adventures_of_huckleberry_finn.md> dc:format "text/markdown" ;
-        dc:type dcmitype:Dataset .
 }
 
 

--- a/examples/adventures_of_huckleberry_finn.ttl
+++ b/examples/adventures_of_huckleberry_finn.ttl
@@ -2,6 +2,7 @@ PREFIX : <http://example.org/terms/>
 PREFIX dc: <http://purl.org/dc/elements/1.1/>
 PREFIX dcmitype: <http://purl.org/dc/dcmitype/>
 PREFIX html: <http://www.w3.org/1999/xhtml/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX schema: <https://schema.org/>
@@ -25,6 +26,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     dc:type dcmitype:Dataset ;
 .
 
+<http://viaf.org/viaf/50566653>
+    rdfs:label "Mark Twain"@en ;
+.
+
 <http://www.wikidata.org/entity/Q101243225>
     rdfs:label "Sarony"@en ;
 .
@@ -38,6 +43,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "Samuel Longhorn Clemens"@en ,
         "塞姆·朗赫恩·克莱門斯"@zh ;
     :portrait <https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/Mark_Twain_by_Sarony%2C_1884.JPG/155px-Mark_Twain_by_Sarony%2C_1884.JPG> ;
+    owl:sameAs
+        <http://viaf.org/viaf/50566653> ,
+        <https://vocab.getty.edu/ulan/500020427> ;
 .
 
 <https://en.wikipedia.org/wiki/Adventures_of_Huckleberry_Finn>
@@ -48,6 +56,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a html:img ;
     rdfs:label "Mark Twain by Sarony, 1884"@en ;
     :creator <http://www.wikidata.org/entity/Q101243225> ;
+.
+
+<https://vocab.getty.edu/ulan/500020427>
+    rdfs:label "Mark Twain"@en ;
 .
 
 <https://en.wikipedia.org/wiki/Mark_Twain>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 66.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "2.9.0"
+version = "2.9.1"
 name = "Articular"
 description = "Create RDF knowledge graphs with Markdown."
 keywords = [


### PR DESCRIPTION
Fix a bug parsing blockquoted hyperlinks for `rdfs:seeAlso` relations.